### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jere-a/Main-website/security/code-scanning/6](https://github.com/jere-a/Main-website/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions for the `GITHUB_TOKEN` used in the workflow. Based on the provided workflow, it appears that the workflow only needs to read repository contents and does not require any write permissions. Therefore, we will set `contents: read` as the minimal permissions required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
